### PR TITLE
MRG: remove some deprecated method calls

### DIFF
--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -899,7 +899,7 @@ class Cifti2Image(FileBasedImage):
         nifti_img = _Cifti2AsNiftiImage.from_file_map(file_map)
 
         # Get cifti2 header
-        for item in nifti_img.get_header().extensions:
+        for item in nifti_img.header.extensions:
             if isinstance(item, Cifti2Extension):
                 cifti_header = item.get_content()
                 break
@@ -913,7 +913,7 @@ class Cifti2Image(FileBasedImage):
         # Construct cifti image
         cifti_img = Cifti2Image(data=nifti_img.get_data()[0, 0, 0, 0],
                                 header=cifti_header,
-                                nifti_header=nifti_img.get_header())
+                                nifti_header=nifti_img.header)
         cifti_img.file_map = nifti_img.file_map
         return cifti_img
 

--- a/nibabel/cifti2/parse_cifti2_fast.py
+++ b/nibabel/cifti2/parse_cifti2_fast.py
@@ -138,7 +138,7 @@ class _Cifti2AsNiftiImage(Nifti2Image):
         self.cifti_img = reduce(lambda accum, newval: newval
                                 if isinstance(newval, Cifti2Extension)
                                 else accum,
-                                self.get_header().extensions, None)
+                                self.header.extensions, None)
         if self.cifti_img is None:
             raise ValueError('Nifti2 header does not contain a CIFTI2 '
                              'extension')

--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -19,7 +19,7 @@ from nose.tools import assert_true, assert_equal, assert_raises
 def compare_xml_leaf(str1, str2):
     x1 = ElementTree.fromstring(str1)
     x2 = ElementTree.fromstring(str2)
-    if len(x1.getchildren()) > 0 or len(x2.getchildren()) > 0:
+    if len(x1) > 0 or len(x2) > 0:
         raise ValueError
 
     return (x1.tag == x2.tag) and (x1.attrib and x2.attrib)


### PR DESCRIPTION
- getchildren method of Element.
- get_header method of SpatialImage
